### PR TITLE
Fix starcoin-framework links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Move is a programming language for writing safe smart contracts originally devel
 
 # Move-Powered Blockchains
 * [0L](https://github.com/OLSF/libra) (in [mainnet](https://0l.network/))
-* [StarCoin](https://github.com/starcoinorg/starcoin) (in [mainnet](https://stcscan.io/))
+* [Starcoin](https://github.com/starcoinorg/starcoin) (in [mainnet](https://stcscan.io/))
 * [Pontem](https://github.com/pontem-network) (in [testnet](https://polkadot.js.org/apps/?rpc=wss://testnet.pontem.network/ws#/explorer))
 * [Celo](https://github.com/celo-org) ([coming soon](https://www.businesswire.com/news/home/20210921006104/en/Celo-Sets-Sights-On-Becoming-Fastest-EVM-Chain-Through-Collaboration-With-Mysten-Labs))
 * [Diem](https://github.com/diem/diem)
@@ -25,45 +25,45 @@ Move is a programming language for writing safe smart contracts originally devel
 * [Move Language Discord](https://discord.gg/kRDkxyEt)
 * [Move @ Mysten Labs](https://discord.gg/yyYQcckG)
 * [Move @ 0L](https://discord.com/invite/Ry2cf4NrbS)
-* [Move @ StarCoin](https://discord.gg/Sek9Cnxt)
+* [Move @ Starcoin](https://discord.gg/Sek9Cnxt)
 
 # Code
 
 ## Fungible Tokens
 * [BasicCoin](https://github.com/diem/move/tree/main/language/documentation/examples/experimental/basic-coin): a toy implementation of an [ERC20](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/)-like fungible token.
 * [Diem](https://github.com/OLSF/libra/blob/main/language/diem-framework/modules/Diem.move): an ERC20-like token with permissioned minting/burning, see also this [spec](https://github.com/diem/dip/blob/main/dips/dip-20.md). Deployed on 0L.
-* [Token](https://github.com/starcoinorg/starcoin/blob/master/vm/stdlib/sources/Token.move): another ERC20-like Token. Deployed on StarCoin.
+* [Token](https://github.com/starcoinorg/starcoin-framework/blob/main/sources/Token.move): another ERC20-like Token. Deployed on Starcoin.
 * [GAS](https://github.com/OLSF/libra/blob/main/language/diem-framework/modules/0L/GAS.move): a token that instantiates the Diem standard above. Deployed on 0L.
-* [STC](https://github.com/starcoinorg/starcoin/blob/master/vm/stdlib/sources/STC.move): a token that instantiates the StarCoin standard above. Deployed on StarCoin.
-* [WEN stablecoin](https://github.com/wenwenprotocol/wen-protocol). Deployed on StarCoin.
-* [FAI stablecoin](https://github.com/BFlyFinance/FAI). Deployed on StarCoin.
-* [FLY stablecoin](https://github.com/BFlyFinance/FLY): a fork of [Ohm](https://www.olympusdao.finance/) implemented in Move. Deployed on StarCoin.
+* [STC](https://github.com/starcoinorg/starcoin-framework/blob/main/sources/STC.move): a token that instantiates the Starcoin standard above. Deployed on Starcoin.
+* [WEN stablecoin](https://github.com/wenwenprotocol/wen-protocol). Deployed on Starcoin.
+* [FAI stablecoin](https://github.com/BFlyFinance/FAI). Deployed on Starcoin.
+* [FLY stablecoin](https://github.com/BFlyFinance/FLY): a fork of [Ohm](https://www.olympusdao.finance/) implemented in Move. Deployed on Starcoin.
 * [Synthetic token backed by a basket containing a reserve of other tokens](https://github.com/OLSF/libra/blob/main/language/diem-framework/modules/XDX.move). From Diem.
 
 ### Non-Fungible Tokens
-* [NFT](https://github.com/starcoinorg/starcoin/blob/master/vm/stdlib/sources/NFT.move): an ERC721-like token. Deployed on StarCoin.
-* [Merkle Airdrop](https://github.com/starcoinorg/starcoin/blob/master/vm/stdlib/sources/MerkleNFT.move): utility for airdropping a large number of NFT's. Deployed on StarCoin.
+* [NFT](https://github.com/starcoinorg/starcoin-framework/blob/main/sources/NFT.move): an ERC721-like token. Deployed on Starcoin.
+* [Merkle Airdrop](https://github.com/starcoinorg/starcoin-framework/blob/main/sources/MerkleNFT.move): utility for airdropping a large number of NFT's. Deployed on Starcoin.
 * [NFT](https://github.com/diem/diem/blob/main/diem-move/diem-framework/experimental/sources/NFT.move): an implementation of a hybrid ERC721/ERC1155-like token. From Diem.
 * [BARS](https://github.com/diem/diem/blob/main/diem-move/diem-framework/experimental/sources/BARS.move): an NFT that instantiates this hybrid standard. From Diem.
-* [MultiToken](https://github.com/starcoinorg/starcoin/tree/master/vm/stdlib): an ERC1155-like token. From Diem.
+* [MultiToken](https://github.com/diem/diem/blob/main/diem-move/diem-framework/experimental/sources/MultiToken.move): an ERC1155-like token. From Diem.
 * [NFTGallery](https://github.com/diem/diem/blob/main/diem-move/diem-framework/experimental/sources/NFTGallery.move): utility for holding multiple NFT's of the same type. From Diem.
 
 ### DeFi
 * [CoinSwap](https://github.com/diem/move/tree/main/language/documentation/examples/experimental/coin-swap) a toy implementation of a [Uniswap](https://uniswap.org/)-like liquidity pool containing two tokens.
-* [StarSwap](https://github.com/Elements-Studio/starswap-core): a Uniswap-style DEX. Deployed on StarCoin.
+* [StarSwap](https://github.com/Elements-Studio/starswap-core): a Uniswap-style DEX. Deployed on Starcoin.
 * [Offer](https://github.com/diem/move/blob/main/language/move-stdlib/nursery/sources/Offer.move): generic implementation of atomic swaps for any pair of assets. 
 
 ### On-Chain Governance
 * [ValidatorUniverse](https://github.com/OLSF/libra/blob/main/language/diem-framework/modules/0L/ValidatorUniverse.move): validator set management. Deployed on 0L.
 * [Oracle](https://github.com/OLSF/libra/blob/main/language/diem-framework/modules/0L/Oracle.move) for on-chain community voting. Deployed on 0L.
-* [DAO](https://github.com/starcoinorg/starcoin/blob/master/vm/stdlib/sources/Dao.move) for on-chain proposals and voting. Deployed on StarCoin.
+* [DAO](https://github.com/starcoinorg/starcoin-framework/blob/main/sources/Dao.move) for on-chain proposals and voting. Deployed on Starcoin.
 * [DiemSystem](https://github.com/diem/diem/blob/main/diem-move/diem-framework/DPN/sources/DiemSystem.move): validator set management. From Diem.
 * [Vote](https://github.com/diem/diem/blob/main/diem-move/diem-framework/experimental/sources/Vote.move): on-chain voting. From Diem.
 
 ### Accounts
 * [Account](https://github.com/diem/diem/blob/main/diem-move/diem-framework/core/sources/Account.move): a generic account for Diem-powered chains. From Diem.
 * [DiemAccount](https://github.com/OLSF/libra/blob/main/language/diem-framework/modules/DiemAccount.move): fork of the above. From 0L.
-* [Account](https://github.com/starcoinorg/starcoin/blob/master/vm/stdlib/sources/Account.move): fork of the above. From StarCoin.
+* [Account](https://github.com/starcoinorg/starcoin-framework/blob/main/sources/Account.move): fork of the above. From Starcoin.
 
 ### Frameworks
 
@@ -73,15 +73,16 @@ The ability to separate blockchain-specific framework logic from the generic fun
 
 * [Diem Framework](https://github.com/diem/diem/tree/main/diem-move/diem-framework/DPN)
 * [0L Framework](https://github.com/OLSF/libra/tree/main/language/diem-framework/modules/0L)
-* [StarCoin Framework](https://github.com/starcoinorg/starcoin/tree/master/vm/stdlib)
+* [Starcoin Framework](https://github.com/starcoinorg/starcoin-framework)
 
 ### Libraries
 * [Move standard library](https://github.com/diem/move/tree/main/language/move-stdlib): utilities intended (but not required) to be used in every platform running Move. From the Move repo.
 * [Move nursery](https://github.com/diem/move/tree/main/language/move-stdlib/nursery): experimental modules that may eventually be promoted into the standard library. From the Move repo.
 * [Decimal](https://github.com/OLSF/libra/blob/main/language/diem-framework/modules/0L/Decimal.move): efficient implementation of a decimal value. From 0L.
-* [Math](https://github.com/starcoinorg/starcoin/blob/master/vm/stdlib/sources/Math.move): math utility functions. From StarCoin.
+* [Math](https://github.com/starcoinorg/starcoin-framework/blob/main/sources/Math.move): math utility functions. From Starcoin.
 * [Compare](https://github.com/diem/move/blob/main/language/move-stdlib/nursery/sources/Compare.move): polymorphic comparison (i.e., compare any two Move values of the same type). From the nursery.
 * [Vault](https://github.com/diem/move/blob/main/language/move-stdlib/nursery/sources/Vault.move) and [ACL](https://github.com/diem/move/blob/main/language/move-stdlib/nursery/sources/ACL.move): libraries for capability and list-based acess control. From the nursery.
+* [Starcoin Framework Commons](https://github.com/starcoinorg/starcoin-framework-commons): libraries for Move commons utility on starcoin-framework. From Starcoin.
 
 ### Miscellaneous
 * [Experimental](https://github.com/diem/move/tree/main/language/evm/examples) project to compile Move source code to EVM bytecode.
@@ -97,7 +98,7 @@ The ability to separate blockchain-specific framework logic from the generic fun
 * [Move Playground](https://playground.pontem.network/), [instructions](https://gist.github.com/borispovod/64b6d23741d8c1f4b0b958a3a74aa68d). Like [Remix](https://remix.ethereum.org/) for Move--alpha version of a Web IDE. Maintained by the Pontem team.
 
 # Wallets
-* StarMask ([install](https://chrome.google.com/webstore/detail/starmask/mfhbebgoclkghebffdldpobeajmbecfk?hl=en), [source code](https://github.com/starcoinorg/starmask-extension)). A wallet for the StarCoin blockchain. Maintained by the StarCoin team.
+* StarMask ([install](https://chrome.google.com/webstore/detail/starmask/mfhbebgoclkghebffdldpobeajmbecfk?hl=en), [source code](https://github.com/starcoinorg/starmask-extension)). A wallet for the Starcoin blockchain. Maintained by the Starcoin team.
 * [bcs-js](https://github.com/pontem-network/lcs-js). JavaScript implementation of the [BCS](https://github.com/diem/bcs) serialization scheme used by Move, may be useful for implementing wallets.
 
 # Papers


### PR DESCRIPTION
1. Rename StarCoin to Starcoin.
2. Starcoin framework migrates from https://github.com/starcoinorg/starcoin/blob/master/vm/stdlib to https://github.com/starcoinorg/starcoin-framework/, so fix the link.
3. Add https://github.com/starcoinorg/starcoin-framework-commons.