### PR TITLE
CI: Fixed broken link check, added Awesome lint check

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,4 +1,4 @@
-name: Broken link check
+name: Broken link & linting check
 on: [push]
 
 jobs:
@@ -18,3 +18,13 @@ jobs:
         recursiveLinks: false # Check all URLs on all reachable pages (could take a while)
     - name: Get the result
       run: echo "${{steps.link-report.outputs.result}}"
+
+  awesome_lint_job:
+    runs-on: ubuntu-latest
+    name: Awesome list lint check
+    steps:
+    - uses: actions/checkout@v2.4.0
+      with:
+        fetch-depth: 0
+    - name: Run awesome-lint 
+      run: npx awesome-lint

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -8,13 +8,13 @@ jobs:
     steps:
     - name: Check for broken links
       id: link-report
-      uses: celinekurpershoek/link-checker@v1.0.1
+      uses: celinekurpershoek/link-checker@37818c3d3586584d04f1a989ac23545adf7a9487
       with:
         # Required:
-        url: 'https://github.com/MystenLabs/awesome-move/blob/main/README.md'
+        url: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/README.md"
         # optional:
         honorRobotExclusions: false
-        ignorePatterns: 'github,google'
+        ignorePatterns: "docs.github.com,visualstudio.com"
         recursiveLinks: false # Check all URLs on all reachable pages (could take a while)
     - name: Get the result
       run: echo "${{steps.link-report.outputs.result}}"

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Code written in Move.
 - [DeFi examples](https://github.com/MystenLabs/sui/tree/main/sui_programmability/examples/defi) - Multiple DeFi example implementations from Sui.
 - [CoinSwap](https://github.com/move-language/move/tree/main/language/documentation/examples/experimental/coin-swap) - A toy implementation of a [Uniswap](https://uniswap.org/)-like liquidity pool containing two tokens.
 - [StarSwap](https://github.com/Elements-Studio/starswap-core) - A Uniswap-style DEX. Deployed on Starcoin.
-- [Offer](https://github.com/move-language/move/blob/main/language/move-stdlib/nursery/sources/Offer.move) - Generic implementation of atomic swaps for any pair of assets.
+- [Offer](https://github.com/move-language/move/blob/main/language/move-stdlib/nursery/sources/offer.move) - Generic implementation of atomic swaps for any pair of assets.
 
 ### On-Chain Governance
 
@@ -126,9 +126,9 @@ The ability to separate blockchain-specific framework logic from the generic fun
 - [Move nursery](https://github.com/move-language/move/tree/main/language/move-stdlib/nursery) - Experimental modules that may eventually be promoted into the standard library. From the Move repo.
 - [Decimal](https://github.com/OLSF/libra/blob/main/language/diem-framework/modules/0L/Decimal.move) - Efficient implementation of a decimal value. From 0L.
 - [Math](https://github.com/starcoinorg/starcoin-framework/blob/main/sources/Math.move) - Math utility functions. From Starcoin.
-- [Compare](https://github.com/move-language/move/blob/main/language/move-stdlib/nursery/sources/Compare.move) - Polymorphic comparison (i.e., compare any two Move values of the same type). From the nursery.
-- [Vault](https://github.com/move-language/move/blob/main/language/move-stdlib/nursery/sources/Vault.move) - Library for capabilities. From the nursery.
-- [ACL](https://github.com/move-language/move/blob/main/language/move-stdlib/nursery/sources/ACL.move) - Library for list-based acess control. From the nursery.
+- [Compare](https://github.com/move-language/move/blob/main/language/move-stdlib/nursery/sources/compare.move) - Polymorphic comparison (i.e., compare any two Move values of the same type). From the nursery.
+- [Vault](https://github.com/move-language/move/blob/main/language/move-stdlib/nursery/sources/vault.move) - Library for capabilities. From the nursery.
+- [ACL](https://github.com/move-language/move/blob/main/language/move-stdlib/nursery/sources/acl.move) - Library for list-based acess control. From the nursery.
 - [TaoHe](https://github.com/taoheorg/taohe) - A collection of nestable Move resources.
 - [Starcoin Framework Commons](https://github.com/starcoinorg/starcoin-framework-commons) - Libraries for Move commons utility on starcoin-framework. From Starcoin.
 


### PR DESCRIPTION
Updated broken links & Fixed broken broken link checker & added GitHub workflow for `npx awesome-lint`.

The broken link checker was broken: the most recent `master` of [link-checker](https://github.com/celinekurpershoek/link-checker) works with `ignorePatterns`, while the `v1.0.1` didn't (https://github.com/celinekurpershoek/link-checker/issues/16#issuecomment-1155043685).

Also now fetching the branch information from the environment variables so the current push/pr/etc. is evaluated against the branch and repo in question, instead of the "main" branch of the upstream repo.
