### PR TITLE
Enable linting and broken link checks for PRs & fix broken links

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,5 +1,9 @@
 name: Broken link & linting check
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   broken_link_checker_job:
@@ -11,7 +15,7 @@ jobs:
       uses: celinekurpershoek/link-checker@37818c3d3586584d04f1a989ac23545adf7a9487
       with:
         # Required:
-        url: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/README.md"
+        url: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/README.md"
         # optional:
         honorRobotExclusions: false
         ignorePatterns: "docs.github.com,visualstudio.com"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ Code written in Move.
 - [STC](https://github.com/starcoinorg/starcoin-framework/blob/main/sources/STC.move) - A token that instantiates the Starcoin standard above. Deployed on Starcoin.
 - [WEN stablecoin](https://github.com/wenwenprotocol/wen-protocol) - Deployed on Starcoin.
 - [FAI stablecoin](https://github.com/BFlyFinance/FAI) - Deployed on Starcoin.
-- [FLY stablecoin](https://github.com/BFlyFinance/FLY) - A fork of [Ohm](https://www.olympusdao.finance/) implemented in Move. Deployed on Starcoin.
 - [Synthetic token backed by a basket containing a reserve of other tokens](https://github.com/OLSF/libra/blob/main/language/diem-framework/modules/XDX.move) - From Diem.
 
 ### Non-Fungible Tokens
@@ -152,7 +151,7 @@ The ability to separate blockchain-specific framework logic from the generic fun
 - [Move Playground](https://playground.pontem.network/) - Like [Remix](https://remix.ethereum.org/) for Move. Alpha version of a Web IDE. See [instructions](https://gist.github.com/borispovod/64b6d23741d8c1f4b0b958a3a74aa68d). Maintained by the Pontem team.
 
 ## Package Managers
-- [Movey](https://www.movey.net/) - A [crates.io](https://crates.io/)-style repository of Move packages.
+- [Movey](https://www.movey.net/) - A crates.io-style repository of Move packages.
 
 ## Wallets
 


### PR DESCRIPTION
We are seeing more contributions from the Move community! :partying_face: Enabling PR and link checks for more convenient testing.

Also fixed crates.io case, and removed FYI since it seems to have disappeared.