### PR TITLE
Add Move Playground JS Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The ability to separate blockchain-specific framework logic from the generic fun
 - [Move Package Manager](https://github.com/move-language/move/tree/main/language/tools/move-cli) - Like `cargo` or `npm` for Move: single CLI (and corresponding Rust API's for other tools to hook into) for building, running, testing, debugging, and verifying Move [packages](https://move-language.github.io/move/). Maintained by the Move core team.
 - [Move Prover](https://github.com/move-language/move/tree/main/language/move-prover) - Formal verification of user-defined specifications written in Move source code. Maintained by the Move core team.
 - [Move Read/Write Set Analyzer](https://github.com/move-language/move/tree/main/language/tools/read-write-set) - Static analysis tool for computing an overapproximation of the global memory touched by a Move program. Maintained by the Move core team.
-- [Move Playground JS Library](https://github.com/imcoding-online/js-move-playground) - Wrapper [Move Playground by Pontem](https://playground.pontem.network/) as javascript library for browser. You can use it to build your own Move Playground.
+- [Move Playground JS Library](https://github.com/imcoding-online/js-move-playground) - Wrapper [Move Playground by Pontem](https://playground.pontem.network/) as Javascript library for browser. You can use it to build your own Move Playground.
 
 ## IDEs
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ The ability to separate blockchain-specific framework logic from the generic fun
 - [Move Package Manager](https://github.com/move-language/move/tree/main/language/tools/move-cli) - Like `cargo` or `npm` for Move: single CLI (and corresponding Rust API's for other tools to hook into) for building, running, testing, debugging, and verifying Move [packages](https://move-language.github.io/move/). Maintained by the Move core team.
 - [Move Prover](https://github.com/move-language/move/tree/main/language/move-prover) - Formal verification of user-defined specifications written in Move source code. Maintained by the Move core team.
 - [Move Read/Write Set Analyzer](https://github.com/move-language/move/tree/main/language/tools/read-write-set) - Static analysis tool for computing an overapproximation of the global memory touched by a Move program. Maintained by the Move core team.
+- [Move Playground JS Library](https://github.com/imcoding-online/js-move-playground) - Wrapper [Move Playground by Pontem](https://playground.pontem.network/) as javascript library for browser. You can use it to build your own Move Playground.
 
 ## IDEs
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The ability to separate blockchain-specific framework logic from the generic fun
 - [Move Package Manager](https://github.com/move-language/move/tree/main/language/tools/move-cli) - Like `cargo` or `npm` for Move: single CLI (and corresponding Rust API's for other tools to hook into) for building, running, testing, debugging, and verifying Move [packages](https://move-language.github.io/move/). Maintained by the Move core team.
 - [Move Prover](https://github.com/move-language/move/tree/main/language/move-prover) - Formal verification of user-defined specifications written in Move source code. Maintained by the Move core team.
 - [Move Read/Write Set Analyzer](https://github.com/move-language/move/tree/main/language/tools/read-write-set) - Static analysis tool for computing an overapproximation of the global memory touched by a Move program. Maintained by the Move core team.
-- [Move Playground JS Library](https://github.com/imcoding-online/js-move-playground) - Wrapper [Move Playground by Pontem](https://playground.pontem.network/) as Javascript library for browser. You can use it to build your own Move Playground.
+- [Move Playground JS Library](https://github.com/imcoding-online/js-move-playground) - Wrapper [Move Playground by Pontem](https://playground.pontem.network/) as JavaScript library for browser. You can use it to build your own Move Playground.
 
 ## IDEs
 


### PR DESCRIPTION
[js-move-playground](https://github.com/imcoding-online/js-move-playground) wrapper [Move Playground by Pontem](https://playground.pontem.network/) as javascript library for browser. Developers can use it to build their own Move Playground.