### PR TITLE
Separating CI into daily and PR/push tasks

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,9 +1,7 @@
-name: Broken link & linting check
+name: Broken link check
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  schedule:
+    - cron: "14 14 * * *"
 
 jobs:
   broken_link_checker_job:
@@ -12,7 +10,7 @@ jobs:
     steps:
     - name: Check for broken links
       id: link-report
-      uses: celinekurpershoek/link-checker@37818c3d3586584d04f1a989ac23545adf7a9487
+      uses: celinekurpershoek/link-checker@v1.0.2
       with:
         # Required:
         url: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/README.md"
@@ -22,13 +20,3 @@ jobs:
         recursiveLinks: false # Check all URLs on all reachable pages (could take a while)
     - name: Get the result
       run: echo "${{steps.link-report.outputs.result}}"
-
-  awesome_lint_job:
-    runs-on: ubuntu-latest
-    name: Awesome list lint check
-    steps:
-    - uses: actions/checkout@v2.4.0
-      with:
-        fetch-depth: 0
-    - name: Run awesome-lint 
-      run: npx awesome-lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,17 @@
+name: Linting check
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  awesome_lint_job:
+    runs-on: ubuntu-latest
+    name: Awesome list lint check
+    steps:
+    - uses: actions/checkout@v2.4.0
+      with:
+        fetch-depth: 0
+    - name: Run awesome-lint 
+      run: npx awesome-lint


### PR DESCRIPTION
The link checker has become flaky, confusing contributors. Moving it from PR/push to daily, bothering only us maintainers.

Keeping the most important CI test (linting) as a PR/push task.

In addition to documentational purposes, this PR also serves as the final test for the new PR CI test.
**Expected result:** lint passing as the only CI test for this PR.
