### PR TITLE
update outdated link to reentrancy explainer

### DIFF
--- a/docs/problem_statement.md
+++ b/docs/problem_statement.md
@@ -10,7 +10,7 @@ The decentralized web needs a lingua franca that will allow platform creators to
 2. **Smart contract languages aren't safe enough.**
 Multimillion dollar exploits are a [regular](https://rekt.news/) occurrence.
 Effective smart contract developers must be experts in both security and their product.
-Language design mistakes (e.g., [re-entrancy](https://consensys.github.io/smart-contract-best-practices/attacks/reentrancy/), insufficient access control features, [silent integer overflow](https://consensys.github.io/smart-contract-best-practices/attacks/insecure-arithmetic/)) increase the attack surface for contracts, make audits expensive and slow, and frustrate the adoption of formal verification.
+Language design mistakes (e.g., [re-entrancy](https://scsfg.io/hackers/reentrancy/), insufficient access control features, [silent integer overflow](https://consensys.github.io/smart-contract-best-practices/attacks/insecure-arithmetic/)) increase the attack surface for contracts, make audits expensive and slow, and frustrate the adoption of formal verification.
 We believe that insufficient language safety is a serious barrier to both mainstream adoption of digital assets and accessible smart contract development.
 
 3. **Smart contract execution layers aren't fast.**


### PR DESCRIPTION
Hey All! The link to the re-entrancy guide is out of date. It has now moved to the link updated in this PR. 

Here's the note on the old page for reference:

> Thank you for visiting the Smart Contract Security Best Practices. Please note that this resource is no longer actively maintained. Instead, we recommend visiting the [Smart Contract Security Field Guide](https://scsfg.io/). The Field Guide is regularly updated and curated by the same security engineer who previously contributed to the Best Practices guide.
> 
> The resource on reentrancy can be found here: https://scsfg.io/hackers/reentrancy/